### PR TITLE
admin-weeks.js — principais mudanças:

### DIFF
--- a/docs/admin/admin.html
+++ b/docs/admin/admin.html
@@ -24,8 +24,6 @@
 
     <!-- ══════════════════════════════════════
          SEÇÃO 1 — REGISTRO DE RESULTADOS
-         O árbitro seleciona o dia ativo e
-         registra os resultados pelos cards
     ══════════════════════════════════════ -->
     <section class="admin-section">
       <h2 class="section-title">Registro de Resultados</h2>
@@ -56,9 +54,6 @@
 
     <!-- ══════════════════════════════════════
          SEÇÃO 3 — GERENCIAR TORNEIOS
-         Separado em duas subseções:
-         A) Novo dia (quadrimestral)
-         B) Novo torneio aberto (diário)
     ══════════════════════════════════════ -->
     <section class="admin-section">
       <h2 class="section-title">Gerenciar Torneios</h2>
@@ -108,7 +103,7 @@
       <div class="admin-subpanel" id="subpanel-diario">
         <p class="subpanel-desc">
           Cria um <strong>torneio aberto</strong> independente (sábados, público geral).<br>
-          <span style="color:var(--text-muted);font-size:.82rem;">Tem check-in, pareamento e resultados próprios.</span>
+          <span style="color:var(--text-muted);font-size:.82rem;">Tem check-in, pareamento por rodada e resultados próprios.</span>
         </p>
 
         <fieldset class="admin-fieldset">
@@ -127,6 +122,10 @@
             <label class="field-label">
               Máx. Jogadores
               <input type="number" id="diario-max-players" class="admin-input" value="24" min="2" max="80">
+            </label>
+            <label class="field-label">
+              Nº de Rodadas
+              <input type="number" id="diario-total-rounds" class="admin-input" value="6" min="1" max="15">
             </label>
           </div>
           <button type="button" id="btn-create-diario" class="btn-primary btn-yellow">
@@ -148,7 +147,7 @@
 
   </div>
 
-  <!-- ── Modal de confirmação ── -->
+  <!-- ── Modal de confirmação de resultado ── -->
   <div id="result-modal" class="modal-overlay" style="display:none;">
     <div class="modal-box">
       <div class="modal-title" id="modal-title">Confirmar resultado</div>

--- a/docs/admin/scripts/admin-weeks.js
+++ b/docs/admin/scripts/admin-weeks.js
@@ -1,8 +1,8 @@
 /* ══════════════════════════════════════════════════════
    ADMIN — Gerenciamento de Sessões
    Suporta:
-     - Dias do torneio quadrimestral
-     - Torneios abertos (diários) autônomos
+     - Dias do torneio quadrimestral (2 rodadas fixas)
+     - Torneios abertos com N rodadas (gerar 1 por vez)
 ══════════════════════════════════════════════════════ */
 
 import { supabase } from "../../scripts/services/supabase.js";
@@ -29,9 +29,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   const quadrimestrais = (allTournaments ?? []).filter(t => t.type === "quadrimestral");
   const diarios        = (allTournaments ?? []).filter(t => t.type === "diario");
 
-  // Preencher selects
-  fillSelect("week-tournament-select",    quadrimestrais, "Nenhum torneio quadrimestral em andamento");
-  fillSelect("diario-tournament-select",  diarios,        "Nenhum torneio aberto em andamento");
+  fillSelect("week-tournament-select",   quadrimestrais, "Nenhum torneio quadrimestral em andamento");
+  fillSelect("diario-tournament-select", diarios,        "Nenhum torneio aberto em andamento");
 
   function fillSelect(id, list, emptyMsg) {
     const sel = document.getElementById(id);
@@ -53,6 +52,9 @@ document.addEventListener("DOMContentLoaded", async () => {
       alert("Preencha todos os campos."); return;
     }
 
+    const btn = document.getElementById("btn-create-week");
+    btn.disabled = true; btn.textContent = "Criando...";
+
     const { error } = await supabase.rpc("create_tournament_session", {
       p_tournament_id:  tournamentId,
       p_session_number: sessionNumber,
@@ -60,23 +62,29 @@ document.addEventListener("DOMContentLoaded", async () => {
       p_max_players:    maxPlayers
     });
 
+    btn.disabled = false; btn.textContent = "+ Criar Dia";
+
     if (error) { alert(error.message || "Erro ao criar dia."); return; }
 
     alert(`✅ Dia ${sessionNumber} criado com sucesso!`);
-    loadSessions();
+    await loadSessions();
   });
 
   /* ── Criar Torneio Aberto (diário) ───────────────── */
   document.getElementById("btn-create-diario")?.addEventListener("click", async () => {
-    const tournamentId = document.getElementById("diario-tournament-select").value;
-    const matchDate    = document.getElementById("diario-date").value;
-    const maxPlayers   = Number(document.getElementById("diario-max-players").value) || 24;
+    const tournamentId  = document.getElementById("diario-tournament-select").value;
+    const matchDate     = document.getElementById("diario-date").value;
+    const maxPlayers    = Number(document.getElementById("diario-max-players").value) || 24;
+    const totalRounds   = Number(document.getElementById("diario-total-rounds")?.value) || 6;
 
     if (!tournamentId || !matchDate) {
       alert("Preencha todos os campos."); return;
     }
 
-    // Torneio aberto é sempre session_number = 1 (único dia)
+    const btn = document.getElementById("btn-create-diario");
+    btn.disabled = true; btn.textContent = "Criando...";
+
+    // 1) Criar a sessão via RPC
     const { error } = await supabase.rpc("create_tournament_session", {
       p_tournament_id:  tournamentId,
       p_session_number: 1,
@@ -84,161 +92,372 @@ document.addEventListener("DOMContentLoaded", async () => {
       p_max_players:    maxPlayers
     });
 
-    if (error) { alert(error.message || "Erro ao criar torneio aberto."); return; }
+    if (error) {
+      btn.disabled = false; btn.textContent = "+ Criar Torneio Aberto";
+      alert(error.message || "Erro ao criar torneio aberto."); return;
+    }
 
-    alert("✅ Torneio aberto criado com sucesso!");
-    loadSessions();
+    // 2) Buscar a sessão recém-criada e atualizar total_rounds
+    const { data: session } = await supabase
+      .from("tournament_sessions")
+      .select("id")
+      .eq("tournament_id", tournamentId)
+      .eq("match_date", matchDate)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (session?.id) {
+      await supabase
+        .from("tournament_sessions")
+        .update({ total_rounds: totalRounds })
+        .eq("id", session.id);
+    }
+
+    btn.disabled = false; btn.textContent = "+ Criar Torneio Aberto";
+    alert(`✅ Torneio aberto criado com ${totalRounds} rodadas!`);
+    await loadSessions();
   });
 
-  /* ── Listar sessões ativas ────────────────────────── */
-  async function loadSessions() {
-    const sessionsList = document.getElementById("weeks-list");
-    if (!sessionsList) return;
+  /* ── Carregar lista de sessões ativas ─────────────── */
+  await loadSessions();
+});
 
-    const { data: sessions, error } = await supabase
-      .from("tournament_sessions")
-      .select(`
-        id, session_number, match_date, max_players, status,
-        tournaments ( id, name, edition, type )
-      `)
-      .in("status", ["open", "in_progress"])
-      .order("match_date", { ascending: false });
+/* ══════════════════════════════════════════════════════
+   LOAD SESSIONS
+══════════════════════════════════════════════════════ */
 
-    if (error) { console.error(error); return; }
+async function loadSessions() {
+  const sessionsList = document.getElementById("weeks-list");
+  if (!sessionsList) return;
 
-    sessionsList.innerHTML = "";
+  sessionsList.innerHTML = `
+    <li style="color:var(--text-muted);font-size:.85rem;padding:10px 0;">Carregando...</li>`;
 
-    if (!sessions?.length) {
-      sessionsList.innerHTML = `
-        <li class="session-item" style="color:var(--text-muted);justify-content:center;border-style:dashed;">
-          Nenhum dia ou torneio aberto ativo.
-        </li>`;
-      return;
-    }
+  const { data: sessions, error } = await supabase
+    .from("tournament_sessions")
+    .select(`
+      id, session_number, match_date, match_time,
+      max_players, status, total_rounds, current_round,
+      tournaments ( id, name, edition, type )
+    `)
+    .in("status", ["open", "in_progress"])
+    .order("match_date", { ascending: true });
 
-    for (const session of sessions) {
-      const { count } = await supabase
-        .from("tournament_checkins")
-        .select("id", { count: "exact", head: true })
-        .eq("tournament_session_id", session.id);
-
-      const t        = session.tournaments;
-      const isOpen   = session.status === "open";
-      const isDiario = t?.type === "diario";
-      const spotsLeft = session.max_players - (count || 0);
-      const pct       = Math.round(((count || 0) / session.max_players) * 100);
-
-      // Label do item:
-      // Quadrimestral → "Dia 3 · Torneio UFABC 2025.1"
-      // Diário        → "Torneio Aberto · Nome do Torneio"
-      const sessionLabel = isDiario
-        ? `Torneio Aberto`
-        : `Dia ${session.session_number}`;
-
-      const typeBadgeHtml = isDiario
-        ? `<span style="font-size:.65rem;font-weight:700;text-transform:uppercase;letter-spacing:.6px;padding:2px 7px;border-radius:10px;background:rgba(240,192,58,.1);border:1px solid rgba(240,192,58,.2);color:var(--yellow);">🎯 Aberto</span>`
-        : `<span style="font-size:.65rem;font-weight:700;text-transform:uppercase;letter-spacing:.6px;padding:2px 7px;border-radius:10px;background:rgba(118,150,86,.12);border:1px solid rgba(118,150,86,.25);color:var(--green);">🏆 Quadrimestral</span>`;
-
-      const li = document.createElement("li");
-      li.className = "session-item";
-      li.innerHTML = `
-        <div class="session-info">
-          <div class="session-title">
-            ${typeBadgeHtml}
-            <span class="session-num">${sessionLabel}</span>
-            <span class="session-tournament">${t?.name ?? "?"}</span>
-            <span class="session-status ${isOpen ? "status-open" : "status-progress"}">
-              ${isOpen ? "aberto" : session.status}
-            </span>
-          </div>
-          <div class="session-meta">
-            📅 ${session.match_date}
-            <span class="session-spots">
-              <span class="spots-count">${count || 0}/${session.max_players}</span> inscritos
-              ${spotsLeft > 0 ? `· ${spotsLeft} vagas` : `· <span style="color:#f87171">Lotado</span>`}
-            </span>
-          </div>
-          <div class="spots-bar">
-            <div class="spots-fill" style="width:${pct}%"></div>
-          </div>
-        </div>
-        <div class="session-actions"></div>`;
-
-      const actionsEl = li.querySelector(".session-actions");
-
-      // ── Botão Gerar Pareamento ──────────────────────
-      if (session.status === "open") {
-        const btnPair = document.createElement("button");
-        btnPair.className = "btn-session-pair";
-        btnPair.innerHTML = "⚡ Gerar Pareamento";
-
-        btnPair.onclick = async () => {
-          const label = isDiario ? "torneio aberto" : `Dia ${session.session_number}`;
-          if (!confirm(`Gerar pareamento para ${label}?\nIsso fechará o check-in e enviará emails.`)) return;
-
-          btnPair.disabled  = true;
-          btnPair.innerHTML = "⏳ Gerando...";
-
-          const { data, error } = await supabase.rpc("generate_pairings", {
-            p_tournament_session_id: session.id
-          });
-
-          if (error || !data?.success) {
-            alert(error?.message || data?.error || "Erro ao gerar pareamento.");
-            btnPair.disabled  = false;
-            btnPair.innerHTML = "⚡ Gerar Pareamento";
-            return;
-          }
-
-          btnPair.innerHTML = "📧 Enviando emails...";
-
-          const { data: { session: authSession } } = await supabase.auth.getSession();
-          const { data: emailData, error: emailError } = await supabase.functions.invoke(
-            "notify-pairings",
-            {
-              body:    { tournament_session_id: session.id },
-              headers: { Authorization: `Bearer ${authSession?.access_token}` }
-            }
-          );
-
-          if (emailError) {
-            alert(`✅ Pareamento gerado!\n⚠️ Problema ao enviar emails. Veja o console.`);
-          } else {
-            const sent   = emailData?.sent ?? 0;
-            const failed = emailData?.results?.filter(r => r.status !== "enviado").length ?? 0;
-            let msg = `✅ Pareamento gerado!\n📧 ${sent} emails enviados.`;
-            if (failed > 0) msg += `\n⚠️ ${failed} email(s) falharam.`;
-            alert(msg);
-          }
-
-          loadSessions();
-        };
-
-        actionsEl.appendChild(btnPair);
-      }
-
-      // ── Botão Encerrar ──────────────────────────────
-      const btnClose = document.createElement("button");
-      btnClose.className = "btn-session-close";
-      btnClose.innerHTML = "✕ Encerrar";
-
-      btnClose.onclick = async () => {
-        const label = isDiario ? "este torneio aberto" : `o Dia ${session.session_number}`;
-        if (!confirm(`Encerrar ${label}?`)) return;
-
-        const { error } = await supabase
-          .from("tournament_sessions")
-          .update({ status: "finished" })
-          .eq("id", session.id);
-
-        if (error) { alert(error.message); return; }
-        loadSessions();
-      };
-
-      actionsEl.appendChild(btnClose);
-      sessionsList.appendChild(li);
-    }
+  if (error || !sessions?.length) {
+    sessionsList.innerHTML = `
+      <li class="session-item" style="color:var(--text-muted);justify-content:center;border-style:dashed;">
+        Nenhum dia ou torneio aberto ativo no momento.
+      </li>`;
+    return;
   }
 
-  loadSessions();
-});
+  // Carregar contagem de inscritos em paralelo
+  const counts = await Promise.all(
+    sessions.map(s =>
+      supabase
+        .from("tournament_checkins")
+        .select("id", { count: "exact", head: true })
+        .eq("tournament_session_id", s.id)
+        .then(({ count }) => count ?? 0)
+    )
+  );
+
+  sessionsList.innerHTML = "";
+
+  sessions.forEach((session, idx) => {
+    const count     = counts[idx];
+    const t         = session.tournaments;
+    const isDiario  = t?.type === "diario";
+    const isOpen    = session.status === "open";
+    const spotsLeft = session.max_players - count;
+    const pct       = Math.min(100, Math.round((count / session.max_players) * 100));
+    const dateStr   = formatDate(session.match_date);
+
+    const accentColor = isDiario ? "var(--yellow)" : "var(--green)";
+    const typeLabel   = isDiario
+      ? `<span style="font-size:.65rem;font-weight:700;text-transform:uppercase;letter-spacing:.6px;
+                      padding:2px 7px;border-radius:10px;
+                      background:rgba(240,192,58,.1);border:1px solid rgba(240,192,58,.2);
+                      color:var(--yellow);">🎯 Torneio Aberto</span>`
+      : `<span style="font-size:.65rem;font-weight:700;text-transform:uppercase;letter-spacing:.6px;
+                      padding:2px 7px;border-radius:10px;
+                      background:rgba(118,150,86,.12);border:1px solid rgba(118,150,86,.25);
+                      color:var(--green);">🏆 Quadrimestral</span>`;
+
+    const sessionLabel = isDiario
+      ? `${t?.name ?? "Torneio Aberto"}${t?.edition ? ` · Ed. ${t.edition}` : ""}`
+      : `Dia ${session.session_number} · ${t?.name ?? "?"}${t?.edition ? ` · Ed. ${t.edition}` : ""}`;
+
+    const statusBadge = isOpen
+      ? `<span class="session-status status-open">aberto</span>`
+      : `<span class="session-status status-progress">em andamento</span>`;
+
+    // ── Bloco de rodadas (só para diário) ────────────
+    let roundsHtml = "";
+    if (isDiario) {
+      const total     = session.total_rounds ?? 6;
+      const current   = session.current_round ?? 0;
+      const nextRound = current + 1;
+      const roundPct  = Math.round((current / total) * 100);
+
+      // Pílulas de rodadas
+      const pills = Array.from({ length: total }, (_, i) => {
+        const r    = i + 1;
+        const done = r <= current;
+        const bg   = done ? accentColor : "var(--border)";
+        const fg   = done ? "#1a1208"   : "var(--text-muted)";
+        return `<span style="display:inline-block;min-width:28px;text-align:center;
+                             padding:3px 7px;border-radius:20px;font-size:.7rem;font-weight:700;
+                             background:${bg};color:${fg};">R${r}</span>`;
+      }).join("");
+
+      // Botão de gerar próxima rodada
+      const btnGerar = current < total
+        ? `<button class="btn-gerar-rodada"
+             data-session-id="${session.id}"
+             data-round="${nextRound}"
+             style="margin-top:10px;background:${accentColor};color:#1a1208;border:none;
+                    font-family:inherit;font-size:.78rem;font-weight:700;
+                    padding:8px 16px;border-radius:var(--radius-sm);cursor:pointer;
+                    transition:opacity .18s;width:auto;">
+             ▶ Gerar Rodada ${nextRound} / ${total}
+           </button>`
+        : `<span style="font-size:.8rem;color:var(--green);font-weight:700;
+                        margin-top:10px;display:inline-block;">
+             ✅ Todas as ${total} rodadas geradas
+           </span>`;
+
+      roundsHtml = `
+        <div style="margin-top:12px;">
+          <div style="display:flex;gap:4px;flex-wrap:wrap;margin-bottom:8px;">${pills}</div>
+          <div style="height:4px;background:var(--border);border-radius:2px;overflow:hidden;">
+            <div style="height:100%;width:${roundPct}%;background:${accentColor};
+                        transition:width .4s;border-radius:2px;"></div>
+          </div>
+          ${btnGerar}
+        </div>`;
+    }
+
+    // ── Botão Gerar Pareamento (quadrimestral / rodada 1 diário) ──
+    let actionBtns = "";
+    if (!isDiario && isOpen) {
+      actionBtns += `
+        <button class="btn-session-pair btn-gerar-quadrimestral"
+          data-session-id="${session.id}"
+          data-session-label="Dia ${session.session_number}">
+          ⚡ Gerar Pareamento
+        </button>`;
+    }
+    if (isDiario && isOpen && (session.current_round ?? 0) === 0) {
+      actionBtns += `
+        <button class="btn-session-pair btn-gerar-rodada"
+          data-session-id="${session.id}"
+          data-round="1"
+          style="background:var(--yellow);color:#1a1208;">
+          ▶ Gerar Rodada 1
+        </button>`;
+    }
+
+    // ── Botão Encerrar ──────────────────────────────
+    actionBtns += `
+      <button class="btn-session-close btn-encerrar"
+        data-session-id="${session.id}"
+        data-label="${sessionLabel}">
+        ✕ Encerrar
+      </button>`;
+
+    const li = document.createElement("li");
+    li.className = "session-item";
+    li.style.borderLeft = `3px solid ${accentColor}`;
+    li.innerHTML = `
+      <div class="session-info" style="flex:1;">
+        <div class="session-title">
+          ${typeLabel}
+          <span class="session-num">${sessionLabel}</span>
+          ${statusBadge}
+        </div>
+        <div class="session-meta">
+          📅 ${dateStr}
+          <span class="session-spots">
+            <span class="spots-count">${count}/${session.max_players}</span> inscritos
+            ${spotsLeft > 0
+              ? `· ${spotsLeft} vagas`
+              : `· <span style="color:#f87171">Lotado</span>`}
+          </span>
+        </div>
+        <div class="spots-bar" style="margin-top:6px;">
+          <div class="spots-fill" style="width:${pct}%;background:${accentColor};"></div>
+        </div>
+        ${roundsHtml}
+      </div>
+      <div class="session-actions" style="display:flex;flex-direction:column;gap:6px;flex-shrink:0;">
+        ${actionBtns}
+      </div>`;
+
+    sessionsList.appendChild(li);
+  });
+
+  /* ── Bind: botões Gerar Rodada (diário) ────────── */
+  sessionsList.querySelectorAll(".btn-gerar-rodada").forEach(btn => {
+    btn.addEventListener("click", async () => {
+      const sessionId = btn.dataset.sessionId;
+      const round     = Number(btn.dataset.round);
+      await generateRoundDiario(sessionId, round, btn);
+    });
+  });
+
+  /* ── Bind: botão Gerar Pareamento (quadrimestral) ─ */
+  sessionsList.querySelectorAll(".btn-gerar-quadrimestral").forEach(btn => {
+    btn.addEventListener("click", async () => {
+      const sessionId = btn.dataset.sessionId;
+      const label     = btn.dataset.sessionLabel;
+      await generatePairingQuadrimestral(sessionId, label, btn);
+    });
+  });
+
+  /* ── Bind: botões Encerrar ─────────────────────── */
+  sessionsList.querySelectorAll(".btn-encerrar").forEach(btn => {
+    btn.addEventListener("click", async () => {
+      const sessionId = btn.dataset.sessionId;
+      const label     = btn.dataset.label;
+      if (!confirm(`Encerrar "${label}"?\nEsta ação não pode ser desfeita.`)) return;
+      const { error } = await supabase
+        .from("tournament_sessions")
+        .update({ status: "finished" })
+        .eq("id", sessionId);
+      if (error) { alert(error.message || "Erro ao encerrar."); return; }
+      await loadSessions();
+    });
+  });
+}
+
+/* ══════════════════════════════════════════════════════
+   GERAR RODADA — Torneio Aberto
+   Chama generate_round_diario(session_id, round_number)
+══════════════════════════════════════════════════════ */
+
+async function generateRoundDiario(sessionId, roundNumber, btn) {
+  const original = btn.textContent;
+  btn.disabled   = true;
+  btn.textContent = `⏳ Gerando rodada ${roundNumber}…`;
+
+  const { data, error } = await supabase.rpc("generate_round_diario", {
+    p_session_id:   sessionId,
+    p_round_number: roundNumber
+  });
+
+  btn.disabled    = false;
+  btn.textContent = original;
+
+  if (error || data?.success === false) {
+    const msg = data?.error || error?.message || "Erro desconhecido.";
+    alert(`❌ Erro ao gerar rodada ${roundNumber}:\n${msg}`);
+    return;
+  }
+
+  const total    = data.total_rounds;
+  const players  = data.total_players;
+  const pairings = data.pairings ?? [];
+  const byeId    = data.bye_player;
+
+  const lines = pairings.map(p =>
+    `Mesa ${p.board}: ${p.player_white} (${p.rating_white}) × ${p.player_black} (${p.rating_black})`
+  );
+  if (byeId) lines.push(`⚠️ BYE: um jogador ficou sem par`);
+
+  alert(
+    `✅ Rodada ${roundNumber} / ${total} gerada!\n` +
+    `${players} jogadores · ${pairings.length} mesas\n\n` +
+    lines.join("\n")
+  );
+
+  // Disparar notificação por email (não-bloqueante)
+  sendEmailNotification(sessionId);
+
+  await loadSessions();
+}
+
+/* ══════════════════════════════════════════════════════
+   GERAR PAREAMENTO — Quadrimestral (2 rodadas)
+   Chama generate_pairings(p_tournament_session_id)
+══════════════════════════════════════════════════════ */
+
+async function generatePairingQuadrimestral(sessionId, label, btn) {
+  if (!confirm(`Gerar pareamento para ${label}?\nIsso fechará o check-in e enviará emails.`)) return;
+
+  btn.disabled    = true;
+  btn.textContent = "⏳ Gerando...";
+
+  const { data, error } = await supabase.rpc("generate_pairings", {
+    p_tournament_session_id: sessionId
+  });
+
+  btn.disabled    = false;
+  btn.textContent = "⚡ Gerar Pareamento";
+
+  if (error || !data?.success) {
+    alert(error?.message || data?.error || "Erro ao gerar pareamento.");
+    return;
+  }
+
+  // Enviar emails de notificação
+  btn.textContent = "📧 Enviando emails...";
+  btn.disabled    = true;
+
+  try {
+    const { data: authSession } = await supabase.auth.getSession();
+    const { data: emailData, error: emailError } = await supabase.functions.invoke(
+      "notify-pairings",
+      {
+        body:    { tournament_session_id: sessionId },
+        headers: { Authorization: `Bearer ${authSession?.session?.access_token}` }
+      }
+    );
+
+    if (emailError) {
+      alert(`✅ Pareamento gerado!\n⚠️ Problema ao enviar emails. Verifique o console.`);
+    } else {
+      const sent   = emailData?.sent ?? 0;
+      const failed = (emailData?.results ?? []).filter(r => r.status !== "enviado").length;
+      let msg = `✅ Pareamento gerado!\n📧 ${sent} emails enviados.`;
+      if (failed > 0) msg += `\n⚠️ ${failed} email(s) falharam.`;
+      alert(msg);
+    }
+  } catch (e) {
+    console.warn("Erro ao enviar emails (não crítico):", e);
+    alert(`✅ Pareamento gerado!\n⚠️ Não foi possível enviar emails.`);
+  }
+
+  btn.disabled    = false;
+  btn.textContent = "⚡ Gerar Pareamento";
+
+  await loadSessions();
+}
+
+/* ══════════════════════════════════════════════════════
+   SEND EMAIL NOTIFICATION (não-bloqueante)
+══════════════════════════════════════════════════════ */
+
+async function sendEmailNotification(sessionId) {
+  try {
+    const { data: authData } = await supabase.auth.getSession();
+    await supabase.functions.invoke("notify-pairings", {
+      body:    { tournament_session_id: sessionId },
+      headers: { Authorization: `Bearer ${authData?.session?.access_token}` }
+    });
+  } catch (e) {
+    console.warn("Notificação de email falhou (não crítico):", e);
+  }
+}
+
+/* ══════════════════════════════════════════════════════
+   HELPERS
+══════════════════════════════════════════════════════ */
+
+function formatDate(dateStr) {
+  const date   = new Date(dateStr + "T12:00:00");
+  const days   = ["Dom","Seg","Ter","Qua","Qui","Sex","Sáb"];
+  const months = ["jan","fev","mar","abr","mai","jun","jul","ago","set","out","nov","dez"];
+  return `${days[date.getDay()]}, ${date.getDate()} ${months[date.getMonth()]}`;
+}


### PR DESCRIPTION
Criar torneio aberto: agora lê o campo diario-total-rounds e salva total_rounds na sessão após criá-la Sessões diárias: exibem pílulas R1 R2 R3… mostrando progresso, barra de rodadas e botão ▶ Gerar Rodada N / Total Sessões quadrimestrais: mantém o botão ⚡ Gerar Pareamento original (chama generate_pairings) generateRoundDiario(): chama a nova RPC generate_round_diario e exibe resumo das mesas geradas generatePairingQuadrimestral(): mantém fluxo original com envio de email via Edge Function Todos os contadores de inscritos carregam em paralelo (mais rápido)